### PR TITLE
Add next-game OG image for the games page

### DIFF
--- a/app/lib/og-image.server.tsx
+++ b/app/lib/og-image.server.tsx
@@ -1,0 +1,149 @@
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import type { ReactNode } from 'react'
+
+import satori from 'satori'
+import sharp from 'sharp'
+import { Resvg } from '@resvg/resvg-js'
+import colors from 'tailwindcss/colors'
+
+import { Season, Team } from '~/schema'
+
+const require = createRequire(import.meta.url)
+
+function fontData(weight: number) {
+	return readFileSync(
+		require.resolve(
+			`@fontsource/nunito-sans/files/nunito-sans-latin-${weight}-normal.woff`
+		)
+	)
+}
+
+const fonts = [
+	{ name: 'Nunito Sans', weight: 400 as const, data: fontData(400) },
+	{ name: 'Nunito Sans', weight: 700 as const, data: fontData(700) },
+	{ name: 'Nunito Sans', weight: 800 as const, data: fontData(800) },
+]
+
+export function teamPalette(team: Team) {
+	return colors[team.color as keyof typeof colors] as Record<string, string>
+}
+
+async function fetchLogoDataUri(teamId: number) {
+	const response = await fetch(
+		`https://files.tweeres.com/teamstats/teams/${teamId}/logo`
+	)
+
+	if (!response.ok) {
+		return null
+	}
+
+	const buffer = Buffer.from(await response.arrayBuffer())
+	// Normalize to a small png: logos are uploaded in whatever format the user
+	// picked (webp, progressive jpeg, 2048px pngs), and resvg can't draw webp
+	const png = await sharp(buffer)
+		.resize(160, 160, { fit: 'cover' })
+		.png()
+		.toBuffer()
+
+	return `data:image/png;base64,${png.toString('base64')}`
+}
+
+// Renders the shared 1200x630 frame (team header, footer) around the given
+// content and returns it as a png Response
+export async function renderTeamOgImage({
+	team,
+	season,
+	footerLabel,
+	children,
+}: {
+	team: Team
+	season: Season | undefined
+	footerLabel?: string
+	children: ReactNode
+}) {
+	const palette = teamPalette(team)
+	const logoDataUri = await fetchLogoDataUri(team.id)
+
+	const svg = await satori(
+		<div
+			style={{
+				width: 1200,
+				height: 630,
+				display: 'flex',
+				flexDirection: 'column',
+				backgroundColor: palette[50],
+				color: palette[900],
+				fontFamily: 'Nunito Sans',
+				padding: '48px 64px',
+			}}
+		>
+			<div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+				{logoDataUri ? (
+					<img
+						alt=""
+						src={logoDataUri}
+						width={80}
+						height={80}
+						style={{ borderRadius: 40, objectFit: 'cover' }}
+					/>
+				) : (
+					<div
+						style={{
+							width: 80,
+							height: 80,
+							borderRadius: 40,
+							backgroundColor: palette[200],
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+							fontSize: 40,
+							fontWeight: 700,
+						}}
+					>
+						{team.name[0]}
+					</div>
+				)}
+				<div style={{ display: 'flex', flexDirection: 'column' }}>
+					<div style={{ fontSize: 56, fontWeight: 800 }}>{team.name}</div>
+					{season ? (
+						<div style={{ fontSize: 28, color: palette[700] }}>
+							{season.name}
+						</div>
+					) : null}
+				</div>
+			</div>
+			<div
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					marginTop: 40,
+					flexGrow: 1,
+				}}
+			>
+				{children}
+			</div>
+			<div
+				style={{
+					display: 'flex',
+					justifyContent: 'space-between',
+					fontSize: 26,
+					color: palette[700],
+				}}
+			>
+				<div>{footerLabel ?? ''}</div>
+				<div>teamstats.tweeres.com</div>
+			</div>
+		</div>,
+		{ width: 1200, height: 630, fonts }
+	)
+
+	const png = new Resvg(svg).render().asPng()
+
+	return new Response(png, {
+		headers: {
+			'Content-Type': 'image/png',
+			'Cache-Control': 'public, max-age=3600',
+		},
+	})
+}

--- a/app/routes/$teamSlug.games.og[.png].tsx
+++ b/app/routes/$teamSlug.games.og[.png].tsx
@@ -1,0 +1,104 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { format, formatISO } from 'date-fns'
+import invariant from 'tiny-invariant'
+import colors from 'tailwindcss/colors'
+
+import { getDb } from '~/lib/getDb'
+import { renderTeamOgImage, teamPalette } from '~/lib/og-image.server'
+
+export async function loader({ params: { teamSlug } }: LoaderFunctionArgs) {
+	invariant(teamSlug, 'Missing teamSlug parameter')
+
+	const db = getDb()
+
+	const team = await db.query.teams.findFirst({
+		where: (teams, { eq }) => eq(teams.slug, teamSlug),
+	})
+
+	if (!team) {
+		throw new Response('Team not found', { status: 404 })
+	}
+
+	const season = await db.query.seasons.findFirst({
+		where: (seasons, { and, eq, gte, lte }) =>
+			and(
+				eq(seasons.teamId, team.id),
+				lte(seasons.startDate, formatISO(new Date())),
+				gte(seasons.endDate, formatISO(new Date()))
+			),
+	})
+
+	const nextGame = await db.query.games.findFirst({
+		where: (games, { and, eq, gt }) =>
+			and(eq(games.teamId, team.id), gt(games.timestamp, formatISO(new Date()))),
+		orderBy: (games, { asc }) => [asc(games.timestamp)],
+	})
+
+	const palette = teamPalette(team)
+
+	return renderTeamOgImage({
+		team,
+		season,
+		children: nextGame ? (
+			<div
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					flexGrow: 1,
+					justifyContent: 'center',
+				}}
+			>
+				<div
+					style={{
+						fontSize: 28,
+						fontWeight: 700,
+						color: palette[700],
+						textTransform: 'uppercase',
+						letterSpacing: 2,
+					}}
+				>
+					Next game
+				</div>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 24,
+						marginTop: 12,
+					}}
+				>
+					<div style={{ fontSize: 64, fontWeight: 800 }}>
+						{`vs ${nextGame.opponent}`}
+					</div>
+					{nextGame.cancelledAt ? (
+						<div
+							style={{ fontSize: 36, fontWeight: 700, color: colors.red[600] }}
+						>
+							Cancelled
+						</div>
+					) : null}
+				</div>
+				<div style={{ fontSize: 44, marginTop: 12 }}>
+					{format(nextGame.timestamp as string, "E MMM d 'at' h:mma")}
+				</div>
+				{nextGame.location ? (
+					<div style={{ fontSize: 44, color: palette[700], marginTop: 8 }}>
+						{nextGame.location}
+					</div>
+				) : null}
+			</div>
+		) : (
+			<div
+				style={{
+					display: 'flex',
+					flexGrow: 1,
+					alignItems: 'center',
+					fontSize: 40,
+					color: palette[700],
+				}}
+			>
+				No upcoming games scheduled
+			</div>
+		),
+	})
+}

--- a/app/routes/$teamSlug.games.tsx
+++ b/app/routes/$teamSlug.games.tsx
@@ -125,8 +125,11 @@ export const meta: MetaFunction = ({ data }: MetaArgs) => {
 		{ property: 'og:description', content: description },
 		{
 			property: 'og:image',
-			content: 'https://teamstats.tweeres.com/games_opengraph.png',
+			content: `${url}/og.png`,
 		},
+		{ property: 'og:image:width', content: '1200' },
+		{ property: 'og:image:height', content: '630' },
+		{ name: 'twitter:card', content: 'summary_large_image' },
 		{ property: 'og:url', content: url },
 	]
 }

--- a/app/routes/$teamSlug.og[.png].tsx
+++ b/app/routes/$teamSlug.og[.png].tsx
@@ -1,51 +1,9 @@
-import { createRequire } from 'node:module'
-import { readFileSync } from 'node:fs'
-
 import type { LoaderFunctionArgs } from '@remix-run/node'
 import { endOfDay, formatISO, parseISO } from 'date-fns'
-import satori from 'satori'
-import sharp from 'sharp'
-import { Resvg } from '@resvg/resvg-js'
 import invariant from 'tiny-invariant'
-import colors from 'tailwindcss/colors'
 
 import { getDb } from '~/lib/getDb'
-
-const require = createRequire(import.meta.url)
-
-function fontData(weight: number) {
-	return readFileSync(
-		require.resolve(
-			`@fontsource/nunito-sans/files/nunito-sans-latin-${weight}-normal.woff`
-		)
-	)
-}
-
-const fonts = [
-	{ name: 'Nunito Sans', weight: 400 as const, data: fontData(400) },
-	{ name: 'Nunito Sans', weight: 700 as const, data: fontData(700) },
-	{ name: 'Nunito Sans', weight: 800 as const, data: fontData(800) },
-]
-
-async function fetchLogoDataUri(teamId: number) {
-	const response = await fetch(
-		`https://files.tweeres.com/teamstats/teams/${teamId}/logo`
-	)
-
-	if (!response.ok) {
-		return null
-	}
-
-	const buffer = Buffer.from(await response.arrayBuffer())
-	// Normalize to a small png: logos are uploaded in whatever format the user
-	// picked (webp, progressive jpeg, 2048px pngs), and resvg can't draw webp
-	const png = await sharp(buffer)
-		.resize(160, 160, { fit: 'cover' })
-		.png()
-		.toBuffer()
-
-	return `data:image/png;base64,${png.toString('base64')}`
-}
+import { renderTeamOgImage, teamPalette } from '~/lib/og-image.server'
 
 export async function loader({ params: { teamSlug } }: LoaderFunctionArgs) {
 	invariant(teamSlug, 'Missing teamSlug parameter')
@@ -105,109 +63,30 @@ export async function loader({ params: { teamSlug } }: LoaderFunctionArgs) {
 		)
 		.slice(0, 5)
 
-	const palette = colors[team.color as keyof typeof colors] as Record<
-		string,
-		string
-	>
-	const logoDataUri = await fetchLogoDataUri(team.id)
+	const palette = teamPalette(team)
 
-	const svg = await satori(
-		<div
-			style={{
-				width: 1200,
-				height: 630,
-				display: 'flex',
-				flexDirection: 'column',
-				backgroundColor: palette[50],
-				color: palette[900],
-				fontFamily: 'Nunito Sans',
-				padding: '48px 64px',
-			}}
-		>
-			<div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
-				{logoDataUri ? (
-					<img
-						alt=""
-						src={logoDataUri}
-						width={80}
-						height={80}
-						style={{ borderRadius: 40, objectFit: 'cover' }}
-					/>
-				) : (
-					<div
-						style={{
-							width: 80,
-							height: 80,
-							borderRadius: 40,
-							backgroundColor: palette[200],
-							display: 'flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-							fontSize: 40,
-							fontWeight: 700,
-						}}
-					>
-						{team.name[0]}
-					</div>
-				)}
-				<div style={{ display: 'flex', flexDirection: 'column' }}>
-					<div style={{ fontSize: 56, fontWeight: 800 }}>{team.name}</div>
-					{season ? (
-						<div style={{ fontSize: 28, color: palette[700] }}>
-							{season.name}
-						</div>
-					) : null}
+	return renderTeamOgImage({
+		team,
+		season,
+		footerLabel: 'Goals and assists leaderboard',
+		children: standings.map((player, index) => (
+			<div
+				key={player.name}
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					fontSize: 36,
+					padding: '10px 0',
+				}}
+			>
+				<div style={{ width: 56, color: palette[700], fontWeight: 700 }}>
+					{`${index + 1}`}
+				</div>
+				<div style={{ flexGrow: 1, fontWeight: 700 }}>{player.name}</div>
+				<div style={{ color: palette[700] }}>
+					{`${player.goals}G ${player.assists}A`}
 				</div>
 			</div>
-			<div
-				style={{
-					display: 'flex',
-					flexDirection: 'column',
-					marginTop: 40,
-					flexGrow: 1,
-				}}
-			>
-				{standings.map((player, index) => (
-					<div
-						key={player.name}
-						style={{
-							display: 'flex',
-							alignItems: 'center',
-							fontSize: 36,
-							padding: '10px 0',
-						}}
-					>
-						<div style={{ width: 56, color: palette[700], fontWeight: 700 }}>
-							{`${index + 1}`}
-						</div>
-						<div style={{ flexGrow: 1, fontWeight: 700 }}>{player.name}</div>
-						<div style={{ color: palette[700] }}>
-							{`${player.goals}G ${player.assists}A`}
-						</div>
-					</div>
-				))}
-			</div>
-			<div
-				style={{
-					display: 'flex',
-					justifyContent: 'space-between',
-					fontSize: 26,
-					color: palette[700],
-				}}
-			>
-				<div>Goals and assists leaderboard</div>
-				<div>teamstats.tweeres.com</div>
-			</div>
-		</div>,
-		{ width: 1200, height: 630, fonts }
-	)
-
-	const png = new Resvg(svg).render().asPng()
-
-	return new Response(png, {
-		headers: {
-			'Content-Type': 'image/png',
-			'Cache-Control': 'public, max-age=3600',
-		},
+		)),
 	})
 }


### PR DESCRIPTION
/:teamSlug/games/og.png renders the team's next game (opponent, date, location, cancelled tag) in the same frame as the leaderboard image. The shared frame moved to app/lib/og-image.server.tsx so both OG routes stay consistent.