### PR TITLE
Add next game line to the team leaderboard OG image

### DIFF
--- a/app/routes/$teamSlug.og[.png].tsx
+++ b/app/routes/$teamSlug.og[.png].tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunctionArgs } from '@remix-run/node'
-import { endOfDay, formatISO, parseISO } from 'date-fns'
+import { endOfDay, format, formatISO, parseISO } from 'date-fns'
 import invariant from 'tiny-invariant'
 
 import { getDb } from '~/lib/getDb'
@@ -61,7 +61,13 @@ export async function loader({ params: { teamSlug } }: LoaderFunctionArgs) {
 				b.assists - a.assists ||
 				a.name.localeCompare(b.name)
 		)
-		.slice(0, 5)
+		.slice(0, 4)
+
+	const nextGame = await db.query.games.findFirst({
+		where: (games, { and, eq, gt }) =>
+			and(eq(games.teamId, team.id), gt(games.timestamp, formatISO(new Date()))),
+		orderBy: (games, { asc }) => [asc(games.timestamp)],
+	})
 
 	const palette = teamPalette(team)
 
@@ -69,24 +75,47 @@ export async function loader({ params: { teamSlug } }: LoaderFunctionArgs) {
 		team,
 		season,
 		footerLabel: 'Goals and assists leaderboard',
-		children: standings.map((player, index) => (
-			<div
-				key={player.name}
-				style={{
-					display: 'flex',
-					alignItems: 'center',
-					fontSize: 36,
-					padding: '10px 0',
-				}}
-			>
-				<div style={{ width: 56, color: palette[700], fontWeight: 700 }}>
-					{`${index + 1}`}
+		// satori can't lay out fragments, so pass the rows as an array
+		children: [
+			...standings.map((player, index) => (
+					<div
+						key={player.name}
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							fontSize: 36,
+							padding: '10px 0',
+						}}
+					>
+						<div style={{ width: 56, color: palette[700], fontWeight: 700 }}>
+							{`${index + 1}`}
+						</div>
+						<div style={{ flexGrow: 1, fontWeight: 700 }}>{player.name}</div>
+						<div style={{ color: palette[700] }}>
+							{`${player.goals}G ${player.assists}A`}
+						</div>
+					</div>
+			)),
+			nextGame ? (
+				<div
+					key="next-game"
+					style={{
+						display: 'flex',
+						marginTop: 'auto',
+						marginBottom: 16,
+						fontSize: 30,
+						gap: 12,
+					}}
+				>
+					<div style={{ fontWeight: 700 }}>Next game</div>
+					<div style={{ color: palette[700] }}>
+						{`vs ${nextGame.opponent} on ${format(
+							nextGame.timestamp as string,
+							"E MMM d 'at' h:mma"
+						)}`}
+					</div>
 				</div>
-				<div style={{ flexGrow: 1, fontWeight: 700 }}>{player.name}</div>
-				<div style={{ color: palette[700] }}>
-					{`${player.goals}G ${player.assists}A`}
-				</div>
-			</div>
-		)),
+			) : null,
+		],
 	})
 }


### PR DESCRIPTION
Trims the leaderboard to 4 rows to make room for a one-line next game above the footer.